### PR TITLE
Add Bits-Pixel_Frame

### DIFF
--- a/mediainfo.xsd
+++ b/mediainfo.xsd
@@ -94,6 +94,7 @@
             <xsd:element name="BitRate_Nominal" minOccurs="0" maxOccurs="1" type="xsd:float"/>
             <xsd:element name="BitRate_Nominal_String" minOccurs="0" maxOccurs="1" type="xsd:string"/>
             <xsd:element name="BitRate_String" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+            <xsd:element name="Bits-Pixel_Frame" minOccurs="0" maxOccurs="1" type="xsd:float"/>
             <xsd:element name="BitsPixel_Frame" minOccurs="0" maxOccurs="1" type="xsd:float"/>
             <xsd:element name="BPM" minOccurs="0" maxOccurs="1" type="xsd:string"/>
             <xsd:element name="BufferSize" minOccurs="0" maxOccurs="1" type="xsd:string"/>


### PR DESCRIPTION
Dash is no more removed from XML element (in practice this is correct, dash is forbidden only as first char) and it creates a change for `Bits-Pixel_Frame` (the only element name with a dash). Hot|fix https://github.com/MediaArea/MediaAreaXml/issues/55.