### PR TITLE
StreamOrder: fix type

### DIFF
--- a/mediainfo.xsd
+++ b/mediainfo.xsd
@@ -699,7 +699,7 @@
             <xsd:element name="StreamKind" minOccurs="0" maxOccurs="1" type="xsd:string"/>
             <xsd:element name="StreamKindPos" minOccurs="0" maxOccurs="1" type="xsd:integer"/>
             <xsd:element name="StreamKind_String" minOccurs="0" maxOccurs="1" type="xsd:string"/>
-            <xsd:element name="StreamOrder" minOccurs="0" maxOccurs="1" type="xsd:integer"/>
+            <xsd:element name="StreamOrder" minOccurs="0" maxOccurs="1" type="xsd:string"/>
             <xsd:element name="StreamSize_Demuxed" minOccurs="0" maxOccurs="1" type="xsd:integer"/>
             <xsd:element name="StreamSize_Demuxed_String1" minOccurs="0" maxOccurs="1" type="xsd:string"/>
             <xsd:element name="StreamSize_Demuxed_String2" minOccurs="0" maxOccurs="1" type="xsd:string"/>


### PR DESCRIPTION
It may be an integer then dash then another integer, e.g. for MPEG-TS it is (0-based) the position of the program in the PAT, dash, the position on the track in the PMT.

Fix https://github.com/MediaArea/MediaAreaXml/issues/73.